### PR TITLE
fix: Keep modal open when a drag started inside is released outside

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,6 +9,9 @@ const App = {
   selectedBrowsePaths: [],
   versionInfo: null,
   libraryViewMode: 'grid',
+  modalBaseline: null,
+  overlayPressed: false,
+  overlayReleased: false,
 
   // ── Init ──
   async init() {
@@ -310,9 +313,36 @@ const App = {
     document.getElementById('modal-title').textContent = title;
     document.getElementById('modal-body').innerHTML = content;
     document.getElementById('modal-overlay').classList.add('active');
+    this.modalBaseline = this.snapshotModal();
   },
   closeModal() {
     document.getElementById('modal-overlay').classList.remove('active');
+    this.modalBaseline = null;
+  },
+  snapshotModal() {
+    const form = document.getElementById('modal-body')?.querySelector('form');
+    if (!form) return null;
+    return JSON.stringify(Array.from(new FormData(form)).filter(([, v]) => typeof v === 'string'));
+  },
+  isModalDirty() {
+    // Files staged in the New Model form aren't part of FormData
+    if (document.getElementById('create-file-input') && this.pendingFiles.length) return true;
+    const current = this.snapshotModal();
+    return current !== null && this.modalBaseline !== null && current !== this.modalBaseline;
+  },
+  dismissModal() {
+    if (this.isModalDirty() && !confirm('Are you sure you want to close this? Your unsaved changes will be lost.')) return;
+    this.closeModal();
+  },
+
+  // ── Overlay click guard (press AND release must land on the overlay) ──
+  overlayMouseDown(e) { this.overlayPressed = e.target === e.currentTarget; },
+  overlayMouseUp(e) { this.overlayReleased = e.target === e.currentTarget; },
+  overlayClicked(e) {
+    const cleanClick = this.overlayPressed && this.overlayReleased && e.target === e.currentTarget;
+    this.overlayPressed = false;
+    this.overlayReleased = false;
+    return cleanClick;
   },
 
   // ─── Dashboard ────────────────────────────────────────────────────────
@@ -1639,7 +1669,10 @@ const App = {
   previewFileModal(url, name, fileType = null) {
     if (typeof Viewer === 'undefined') return;
     const modalHtml = `
-      <div class="modal-overlay active" style="z-index:9999;background:rgba(0,0,0,0.85)" onclick="App.closePreviewFileModal(event)">
+      <div class="modal-overlay active" style="z-index:9999;background:rgba(0,0,0,0.85)"
+        onmousedown="App.overlayMouseDown(event)"
+        onmouseup="App.overlayMouseUp(event)"
+        onclick="if(App.overlayClicked(event))App.closePreviewFileModal(event)">
         <div class="modal" style="width:96vw;max-width:1400px;height:92vh;max-height:92vh;display:flex;flex-direction:column;overflow:hidden" onclick="event.stopPropagation()">
           <div class="modal-header" style="padding:16px 24px">
             <h5 class="modal-title" style="margin:0">${name}</h5>
@@ -2320,13 +2353,19 @@ const App = {
 };
 
 // ── Close modal on overlay click ──
-document.getElementById('modal-overlay')?.addEventListener('click', (e) => {
-  if (e.target === e.currentTarget) App.closeModal();
+const modalOverlay = document.getElementById('modal-overlay');
+modalOverlay?.addEventListener('mousedown', (e) => App.overlayMouseDown(e));
+modalOverlay?.addEventListener('mouseup', (e) => App.overlayMouseUp(e));
+modalOverlay?.addEventListener('click', (e) => {
+  if (App.overlayClicked(e)) App.dismissModal();
 });
 
 // ── Close modal on Escape & Ctrl+K search shortcut ──
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') App.closeModal();
+  if (e.key === 'Escape') {
+    if (document.getElementById('preview-modal-container')) return; // preview has its own handler
+    if (document.getElementById('modal-overlay')?.classList.contains('active')) App.dismissModal();
+  }
   if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
     e.preventDefault();
     const searchInput = document.getElementById('search-input');


### PR DESCRIPTION
### The problem

Press the mouse inside a modal and release it outside, and the modal closes — losing whatever you had typed. It is easy to hit while selecting text in the **Description** textarea of **New Model**, dragging a scrollbar, or orbiting a model in the 3D preview.

### Cause

A `click` event fires on the **nearest common ancestor of `mousedown` and `mouseup`**. Press inside the modal, release on the overlay, and that ancestor *is* the overlay, so the existing check passed:

```js
document.getElementById('modal-overlay')?.addEventListener('click', (e) => {
  if (e.target === e.currentTarget) App.closeModal();
});
```

The `onclick="event.stopPropagation()"` on the preview modal's inner `.modal` does not help here, because the modal element is never in the propagation path when the target is the overlay itself.

### The fix

The overlay now closes only when **both** the press and the release land on it (`App.overlayMouseDown` / `overlayMouseUp` / `overlayClicked`). This also covers the reverse drag — press on the overlay, release inside the modal. The same guard is applied to the 3D file preview modal, where OrbitControls drags routinely leave the modal bounds.

On top of that, dismissing a modal that has **unsaved changes** via the overlay or <kbd>Esc</kbd> now asks for confirmation, using a plain `confirm()` to match the existing ones in `app.js`. Dirtiness is a `FormData` snapshot taken when the modal opens, compared on dismiss, plus `pendingFiles` for files staged in the New Model form.

Deliberately unchanged: the **Cancel** buttons, the **✕** button, and every successful submit still close immediately — those are deliberate actions, and `closeModal()` keeps its old unconditional behaviour so no existing call site changes meaning.

### Testing

Verified in the browser against a local instance. Confirmed the drag really does fire a `click` whose target is the overlay (so the old code closed on it) and that the modal now survives it:

| Case | Result |
| --- | --- |
| Type into New Model, drag from the textarea out to the overlay | stays open, text intact |
| Reverse drag: press on overlay, release inside modal | stays open |
| Clean click on the overlay, untouched form | closes, no prompt |
| Clean click / <kbd>Esc</kbd> with edits | prompts; Cancel keeps the text, OK closes |
| **Log Print** (pre-filled date + checked box) and **Edit Model**, untouched | close with no prompt |
| Cancel button and ✕ with edits present | close instantly, no prompt |
| File staged in New Model, then <kbd>Esc</kbd> | prompts |
| Unrelated modal opened afterwards | no prompt — no stale `pendingFiles` leak |
| Preview modal: orbit drag ending outside | stays open; clean backdrop click, <kbd>Esc</kbd> and ✕ still close it |
| <kbd>Esc</kbd> with a preview stacked over an edited form | closes only the preview, no prompt |

Frontend only — one file, `public/js/app.js`. No server, dependency, or build changes.